### PR TITLE
Updated Build server for Docker 1.3 with TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ build-models/.settings
 
 build-server/target/
 build-server/.settings
+.DS_Store

--- a/build-server/pom.xml
+++ b/build-server/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>build-server</artifactId>
 	<packaging>jar</packaging>
-	
+
 	<parent>
 		<groupId>nl.tudelft.ewi.build</groupId>
 		<artifactId>build-server-parent</artifactId>
@@ -23,6 +23,11 @@
 			<version>3.1.0</version>
 		</dependency>
 		<dependency>
+			<groupId>javax.ejb</groupId>
+			<artifactId>ejb-api</artifactId>
+			<version>3.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-webapp</artifactId>
 			<version>${jetty.version}</version>
@@ -38,6 +43,25 @@
 			<groupId>nl.tudelft.ewi.build</groupId>
 			<artifactId>build-models</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.spotify</groupId>
+			<artifactId>docker-client</artifactId>
+			<version>2.7.1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.glassfish.jersey.core</groupId>
+					<artifactId>jersey-client</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.glassfish.jersey.connectors</groupId>
+					<artifactId>jersey-apache-connector</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.glassfish.jersey.media</groupId>
+					<artifactId>jersey-media-json-jackson</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.xeustechnologies</groupId>

--- a/build-server/src/main/java/nl/tudelft/ewi/build/Config.java
+++ b/build-server/src/main/java/nl/tudelft/ewi/build/Config.java
@@ -16,5 +16,7 @@ public interface Config {
 	String getClientId();
 	
 	String getClientSecret();
+
+	String getCertificateDirectory();
 	
 }

--- a/build-server/src/main/java/nl/tudelft/ewi/build/PropertyBasedConfig.java
+++ b/build-server/src/main/java/nl/tudelft/ewi/build/PropertyBasedConfig.java
@@ -52,5 +52,10 @@ public class PropertyBasedConfig implements Config {
 	public String getClientSecret() {
 		return properties.getProperty("authorization.client-secret");
 	}
+
+	@Override
+	public String getCertificateDirectory() {
+		return properties.getProperty("docker.certificates");
+	}
 	
 }

--- a/build-server/src/main/java/nl/tudelft/ewi/build/SimpleConfig.java
+++ b/build-server/src/main/java/nl/tudelft/ewi/build/SimpleConfig.java
@@ -14,5 +14,6 @@ public class SimpleConfig implements Config {
 	private String workingDirectory = "/workshop";
 	private String clientId = "test-client";
 	private String clientSecret = "test-secret";
+	private String certificateDirectory = "/certs";
 
 }

--- a/build-server/src/main/resources/config.properties
+++ b/build-server/src/main/resources/config.properties
@@ -2,8 +2,9 @@ authorization.client-id = MichaelLaptop
 authorization.client-secret = t2hLCXVE
 
 docker.max-containers = 3
-docker.host = http://localhost:4243
-docker.staging-directory = /home/michael/workspace
+docker.host = https://192.168.59.103:2376
+docker.staging-directory = /workspace
 docker.working-directory = /workspace
+docker.certificates = /Users/jgmeligmeyling/.boot2docker/certs/boot2docker-vm
 
 http.port = 8082

--- a/build-server/src/test/java/nl/tudelft/ewi/build/docker/DockerManagerImplTest.java
+++ b/build-server/src/test/java/nl/tudelft/ewi/build/docker/DockerManagerImplTest.java
@@ -1,7 +1,10 @@
 package nl.tudelft.ewi.build.docker;
 
 import com.google.common.base.Joiner;
+import com.spotify.docker.client.DockerCertificateException;
+
 import nl.tudelft.ewi.build.SimpleConfig;
+
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -12,7 +15,7 @@ public class DockerManagerImplTest {
 	private DockerManager manager;
 	
 	@Before
-	public void setUp() {
+	public void setUp() throws DockerCertificateException {
 		Assume.assumeTrue("Skipping Docker related tests. If these tests should run set VM argument: "
 				+ "-Ddocker-tests.run=true", "true".equalsIgnoreCase(System.getProperty("docker-tests.run")));
 		

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 
 		<guice.version>3.0</guice.version>
 		<hibernate.version>4.2.7.Final</hibernate.version>
-		<jackson.version>2.3.0</jackson.version>
-		<resteasy.version>3.0.4.Final</resteasy.version>
+		<jackson.version>2.4.4</jackson.version>
+		<resteasy.version>3.0.10.Final</resteasy.version>
 		<slf4j.version>1.7.5</slf4j.version>
 	</properties>
 


### PR DESCRIPTION
This PR adds the hostnameVerifier and sslContext from the Spotify Docker client to our Docker client in order to work with the certificates required for the boot2docker Docker host. While this PR is required in order to use the Docker client with boot2docker, **we might want to close this PR without merging because:**

* the deployed servers do not use boot2docker
* we can provide a `vagrantfile` ( #11 ) with a docker host for development
* There is an open PR to switch to the spotify client all together #14 