### PR TITLE
BuildRequest changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ build-models/.settings
 
 build-server/target/
 build-server/.settings
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ boot2docker ssh
 sudo mkdir /workspace
 sudo mount -t vboxsf -o uid=1000,gid=50 workspace /workspace
 ```
+**Note that these steps have to be repeated each time the boot2docker virtual machine is created**
 
 Add docker images to Docker
 ------------

--- a/build-models/src/main/java/nl/tudelft/ewi/build/jaxrs/models/BuildRequest.java
+++ b/build-models/src/main/java/nl/tudelft/ewi/build/jaxrs/models/BuildRequest.java
@@ -11,6 +11,6 @@ public class BuildRequest {
 
 	private String callbackUrl;
 
-	private int timeout;
+	private Integer timeout;
 
 }

--- a/build-server/src/main/java/nl/tudelft/ewi/build/builds/BuildManager.java
+++ b/build-server/src/main/java/nl/tudelft/ewi/build/builds/BuildManager.java
@@ -56,8 +56,8 @@ public class BuildManager {
 		futures.put(buildId, future);
 		runners.put(buildId, runner);
 
-		int timeout = request.getTimeout();
-		if (timeout > 0) {
+		Integer timeout = request.getTimeout();
+		if (timeout != null && timeout > 0) {
 			log.debug("Build will automatically terminate in: {} seconds...", timeout);
 			Runnable terminator = createTerminator(buildId);
 			final Future<?> terminatorFuture = schedulerService.schedule(terminator, timeout, TimeUnit.SECONDS);

--- a/build-server/src/main/java/nl/tudelft/ewi/build/extensions/staging/GitStagingDirectoryPreparer.java
+++ b/build-server/src/main/java/nl/tudelft/ewi/build/extensions/staging/GitStagingDirectoryPreparer.java
@@ -41,7 +41,10 @@ public class GitStagingDirectoryPreparer implements StagingDirectoryPreparer<Git
 			log.info("Checking out revision: {}", source.getCommitId());
             CheckoutCommand checkout = git.checkout();
             checkout.setStartPoint(source.getCommitId());
-            checkout.setName(source.getBranchName());
+            if(source.getBranchName() != null)
+            	checkout.setName(source.getBranchName());
+            else
+            	checkout.setName("head");
             checkout.call();
 		}
 		catch (GitAPIException e) {


### PR DESCRIPTION
Throughout Devhub we use `Integers` to store the build timeout value, which can also be `null`. In the build server, we used `ints` which cause `NullPointerExceptions` for some input. These changes allow builds that do not specify a build timeout.

Another change in this PR is that the requester doesn't necessarily have to specify the branch name. For example when requesting a commit to be build, finding out to which branch it belongs can be difficult (we would have to add a command for the git server). Since we're already pulling all the branches, we can just checkout a commit to the `head` in the working directory when the branch name is unknown.