### PR TITLE
Raise docker client version to easy dev setup on mac os

### DIFF
--- a/build-server/pom.xml
+++ b/build-server/pom.xml
@@ -27,13 +27,32 @@
 			<artifactId>jetty-webapp</artifactId>
 			<version>${jetty.version}</version>
 		</dependency>
+		<!--Needed for the Stateless annotation that hibernate validator needs-->
+		<dependency>
+			<groupId>javax.ejb</groupId>
+			<artifactId>ejb-api</artifactId>
+			<version>3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>resteasy-client</artifactId>
+			<version>${resteasy.version}</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>slf4j-simple</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
 
 		<!-- Utilities -->
-	
+		<!--We use the shaded artifact to minimalise conflicts between jersey and RestEasy-->
 		<dependency>
-		  <groupId>com.spotify</groupId>
-		  <artifactId>docker-client</artifactId>
-		  <version>2.7.19</version>
+			<groupId>com.spotify</groupId>
+			<artifactId>docker-client</artifactId>
+			<classifier>shaded</classifier>
+			<version>8.3.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>

--- a/build-server/src/main/java/nl/tudelft/ewi/build/BuildServerModule.java
+++ b/build-server/src/main/java/nl/tudelft/ewi/build/BuildServerModule.java
@@ -44,7 +44,7 @@ public class BuildServerModule extends AbstractModule {
 		});
 		
 		bind(DockerClient.class).toInstance(DefaultDockerClient.fromEnv()
-				.readTimeoutMillis(DefaultDockerClient.NO_TIMEOUT)
+				.readTimeoutMillis(0)
 				.build());
 		
 		findResourcesWith(Path.class);

--- a/build-server/src/main/java/nl/tudelft/ewi/build/jaxrs/BuildsResource.java
+++ b/build-server/src/main/java/nl/tudelft/ewi/build/jaxrs/BuildsResource.java
@@ -13,7 +13,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.core.MediaType;
@@ -21,6 +20,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.Response.StatusType;
 
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.util.Base64;
 
 import com.google.common.base.Strings;
@@ -72,7 +72,7 @@ public class BuildsResource {
 						log.info("Returning build results to callback URL: {}",
 							buildRequest.getCallbackUrl());
 						for (int i = 0; i <= 4; i++) {
-							Client client = ClientBuilder.newClient();
+							Client client = new ResteasyClientBuilder().build();
 							try {
 								Response response = prepareCallback(client).post(
 									Entity.json(result));

--- a/build-server/src/main/resources/config.properties
+++ b/build-server/src/main/resources/config.properties
@@ -2,6 +2,7 @@ authorization.client-id = MichaelLaptop
 authorization.client-secret = t2hLCXVE
 
 docker.max-containers = 3
+
 docker.staging-directory = /workspace
 docker.working-directory = /workspace
 docker.user = root

--- a/build-server/src/test/java/com/spotify/docker/client/MockedLogStream.java
+++ b/build-server/src/test/java/com/spotify/docker/client/MockedLogStream.java
@@ -1,36 +1,54 @@
 package com.spotify.docker.client;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.LinkedList;
 import java.util.Queue;
 
 import org.apache.commons.io.input.NullInputStream;
 
-public class MockedLogStream extends LogStream {
+public class MockedLogStream implements LogStream {
 
 	private final Queue<LogMessage> logMessages;
 
 	public MockedLogStream() {
-		super(new NullInputStream(0));
 		this.logMessages = new LinkedList<LogMessage>();
 	}
-
-	@Override
-	protected LogMessage computeNext() {
-		if (logMessages.isEmpty())
-			return endOfData();
-		return logMessages.remove();
-	}
-
 	public void addMessage(final LogMessage message) {
 		logMessages.add(message);
 	}
-	
+
 	@Override
-	public void close() {
-		try {
-			super.close();
-		}
-		catch (Throwable t) {}
+	public String readFully() {
+		return "";
 	}
 
+	@Override
+	public void attach(OutputStream stdout, OutputStream stderr) throws IOException {
+
+	}
+
+	@Override
+	public void attach(OutputStream stdout, OutputStream stderr, boolean closeAtEof) throws IOException {
+
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public boolean hasNext() {
+		return !logMessages.isEmpty();
+	}
+
+	@Override
+	public LogMessage next() {
+		return logMessages.remove();
+	}
+
+	@Override
+	public void remove() {
+
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,15 +7,15 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<guice.version>3.0</guice.version>
 		<hibernate.version>4.2.7.Final</hibernate.version>
-		<jackson.version>2.3.0</jackson.version>
-		<resteasy.version>3.0.4.Final</resteasy.version>
+		<jackson.version>2.6.3</jackson.version>
+		<resteasy.version>3.0.19.Final</resteasy.version>
 		<slf4j.version>1.7.5</slf4j.version>
 	</properties>
 
@@ -48,7 +48,22 @@
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-hibernatevalidator-provider</artifactId>
 			<version>${resteasy.version}</version>
+			<!--We exclude weld because it had conflicts with the ByteStreams in guava-->
+			<exclusions>
+				<exclusion>
+					<groupId>org.jboss.weld.se</groupId>
+					<artifactId>weld-se</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
+
+		<!--However the annotations of weld were a implicit transitive dependency so we re add them here.-->
+		<dependency>
+			<groupId>javax.enterprise</groupId>
+			<artifactId>cdi-api</artifactId>
+			<version>1.2</version>
+		</dependency>
+
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-guava</artifactId>
@@ -103,7 +118,7 @@
 		<dependency>
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>
-			<version>0.9.8</version>
+			<version>0.9.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -113,7 +128,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>15.0</version>
+			<version>18.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Moved the docker exception to a different package.
Reimplemented the MockedLogStream.
Move volumes to appropriate spot in new api version

The version bump resulted in a bunch of dependency conflicts.
Ranging from guava to jackson versions.

In the end the solution is the shaded spotify jar,
with an updated version of rest easy that excludes a few
conflicting dependencies.